### PR TITLE
Implement grace unlock inside of Bingo Randomizer

### DIFF
--- a/src/ERBingoRandomizer/Const.cs
+++ b/src/ERBingoRandomizer/Const.cs
@@ -12,6 +12,7 @@ public static class Const {
     public const string RegulationName = "regulation.bin";
     public const string ItemMsgBNDPath = "/msg/engus/item.msgbnd.dcx";
     public const string MenuMsgBNDPath = "/msg/engus/menu.msgbnd.dcx";
+    public const string CommonEventPath = "/event/common.emevd.dcx";
     // Params  
     public const string EquipMtrlSetParamName = "EquipMtrlSetParam.param";
     public const string EquipParamWeaponName = "EquipParamWeapon.param";

--- a/src/ERBingoRandomizer/Randomizer/RandoResource.cs
+++ b/src/ERBingoRandomizer/Randomizer/RandoResource.cs
@@ -46,6 +46,8 @@ public class RandoResource {
     internal Param ItemLotParamEnemy;
     internal Param ShopLineupParam;
     internal Param AtkParamPc;
+    // EMEVDs
+    internal EMEVD CommonEmevd;
     // Dictionaries
     internal Dictionary<int, EquipParamWeapon> WeaponDictionary;
     internal Dictionary<int, EquipParamWeapon> CustomWeaponDictionary;
@@ -83,6 +85,8 @@ public class RandoResource {
         getParams();
         _cancellationToken.ThrowIfCancellationRequested();
         getFmgs();
+        _cancellationToken.ThrowIfCancellationRequested();
+        getEmevds();
         _cancellationToken.ThrowIfCancellationRequested();
         buildDictionaries();
         _cancellationToken.ThrowIfCancellationRequested();
@@ -126,6 +130,12 @@ public class RandoResource {
         foreach (BinderFile file in MenuMsgBnd.Files) {
             getFmgs(file);
         }
+    }
+    private void getEmevds()
+    {
+        // This is only used in S3, but always fetch and write them for now.
+        byte[] emevdBytes = getOrOpenFile(Const.CommonEventPath);
+        CommonEmevd = EMEVD.Read(emevdBytes);
     }
     private byte[] getOrOpenFile(string path) {
         if (File.Exists($"{Config.CachePath}/{path}")) {

--- a/src/ERBingoRandomizer/Randomizer/Utils.cs
+++ b/src/ERBingoRandomizer/Randomizer/Utils.cs
@@ -109,7 +109,8 @@ public partial class BingoRandomizer {
         Directory.CreateDirectory(Path.GetDirectoryName($"{Const.BingoPath}/{Const.MenuMsgBNDPath}") ?? throw new InvalidOperationException());
         setBndFile(_resources.MenuMsgBnd, Const.GR_LineHelpName, _resources.LineHelpFmg.Write());
         File.WriteAllBytes($"{Const.BingoPath}/{Const.MenuMsgBNDPath}", _resources.MenuMsgBnd.Write());
-
+        Directory.CreateDirectory(Path.GetDirectoryName($"{Const.BingoPath}/{Const.CommonEventPath}") ?? throw new InvalidOperationException());
+        File.WriteAllBytes($"{Const.BingoPath}/{Const.CommonEventPath}", _resources.CommonEmevd.Write());
     }
     private void logReplacementDictionary(Dictionary<int, ItemLotEntry> dict) {
         foreach (KeyValuePair<int, ItemLotEntry> pair in dict) {


### PR DESCRIPTION
This makes fixed edits to common.emevd.dcx, so regulation.bin changes do not appear to be required at this point. This should be considerably more future-proof, however.